### PR TITLE
Added support for permalinks

### DIFF
--- a/common/docs/docs.jsx
+++ b/common/docs/docs.jsx
@@ -28,6 +28,22 @@ export default DocView = React.createClass({
   getMeteorData() {
     const sub = Meteor.subscribe("CacheDocs", this.props.params);
 
+    const baseURL = global.baseURL ? global.baseURL.substring(1) : null;
+    const branch = this.props.params.branch || Meteor.settings.public.redoc.branch || "master";
+
+    // Set params defaults
+    const query = {};
+    query.slug = this.props.params.splat;
+    if (baseURL) {
+      query.slug = this.props.params.splat.replace(new RegExp(`^${baseURL}/?`), '');
+    }
+
+    // defaults to welcome page if no particular doc requested
+    if (this.props.params.splat === '' || this.props.params.splat === baseURL || !query.slug) {
+      query.slug = `${branch}/welcome`;
+    }
+
+
     if (Meteor.isClient) {
       const search = DocSearch.getData({
         transform: (matchText, regExp) => {
@@ -37,7 +53,7 @@ export default DocView = React.createClass({
 
       return {
         docIsLoaded: sub.ready(),
-        currentDoc: ReDoc.Collections.Docs.findOne(this.props.params),
+        currentDoc: ReDoc.Collections.Docs.findOne(query),
         search: search
       };
     }
@@ -45,7 +61,7 @@ export default DocView = React.createClass({
     if (Meteor.isServer) {
       return {
         docIsLoaded: true,
-        currentDoc: ReDoc.Collections.Docs.findOne(this.props.params),
+        currentDoc: ReDoc.Collections.Docs.findOne(query),
         search: []
       };
     }

--- a/common/docs/toc.jsx
+++ b/common/docs/toc.jsx
@@ -67,13 +67,7 @@ export default DocView = React.createClass({
 
     for (let item of parentItems) {
       const branch = this.props.params.branch || Meteor.settings.public.redoc.branch || "master";
-      let url = '';
-
-      if (Meteor.settings.public.redoc.repoInLinks) {
-        url += `${global.baseURL}/${item.repo}/${branch}/${item.alias}`;
-      } else {
-        url += `${global.baseURL}/${branch}/${item.alias}`;
-      }
+      let url = `${global.baseURL}/${item.slug}`;
 
       let subList;
 

--- a/common/main.jsx
+++ b/common/main.jsx
@@ -13,15 +13,9 @@ const analytics = analytics || null;
 
 const baseURL = s.rtrim(url.parse(__meteor_runtime_config__.ROOT_URL).pathname, '/') || '';
 const AppRoutes = (
-  <Route component={Layout} path="/">
+  <Route component={Layout} path="*">
     <Route component={RedocAdmin} path="/redoc" />
-    <Route component={Docs} path={baseURL} />
-    <Route component={Docs} path="/:alias" />
-    <Route component={Docs} path={`${baseURL}/:alias`} />
-    <Route component={Docs} path="/:branch/:alias" />
-    <Route component={Docs} path={`${baseURL}/:branch/:alias`} />
-    <Route component={Docs} path="/:repo/:branch/:alias" />
-    <Route component={Docs} path={`${baseURL}/:repo/:branch/:alias`} />
+    <Route component={Docs} path={`${baseURL}/:slug`} />
     <IndexRoute component={Docs} />
   </Route>
 );

--- a/packages/redoc-core/lib/schemas.js
+++ b/packages/redoc-core/lib/schemas.js
@@ -102,6 +102,10 @@ ReDoc.Schemas.TOC = new SimpleSchema({
     type: String,
     optional: true
   },
+  slug: {
+    type: String,
+    optional: true
+  },
   documentTOC: {
     type: [ReDoc.Schemas.DocumentTOC],
     optional: true
@@ -155,6 +159,10 @@ ReDoc.Schemas.Docs = new SimpleSchema({
   },
   docPath: {
     type: String
+  },
+  slug: {
+    type: String,
+    optional: true
   },
   docParsed: {
     type: [Object],

--- a/packages/redoc-core/private/redoc.json
+++ b/packages/redoc-core/private/redoc.json
@@ -3,6 +3,7 @@
     "org": "RocketChat",
     "repo": "Rocket.Chat.Docs",
     "label": "Rocket.Chat Docs",
-    "description": "Rocket.Chat Documentation"
+    "description": "Rocket.Chat Documentation",
+    "docPath": "README.md"
   }]
 }

--- a/packages/redoc-core/server/methods.js
+++ b/packages/redoc-core/server/methods.js
@@ -39,14 +39,14 @@ md = require("markdown-it")({
     if (!isImage && !hasProtocol) {
       switch (link.charAt(0)) {
       case "#":
-        newLink = `${global.baseURL}` + (Meteor.settings.public.redoc.repoInLinks ? `/${env.repo}` : '') + `/${env.branch}/${env.alias}${link}`;
+        newLink = `${global.baseURL}/${env.slug}${link}`;
         break;
       case "/":
         tocItem = ReDoc.Collections.TOC.findOne({
           docPath: link.substring(1)
         });
         if (tocItem) {
-          newLink = `${global.baseURL}` + (Meteor.settings.public.redoc.repoInLinks ? `/${tocItem.repo}` : '') + `/${env.branch}/${tocItem.alias}`;
+          newLink = `${global.baseURL}/${item.slug}`;
         }
         break;
       default:
@@ -83,13 +83,14 @@ function getDoc(options) {
     branch: options.branch || "development",
     repo: options.repo,
     docPath: tocItem.docPath,
-    alias: tocItem.alias
+    alias: tocItem.alias,
+    slug: tocItem.slug
   });
 }
 
 
 function loadAndSaveDoc(docData) {
-  const { alias, docPath, repo, rawUrl, branch } = docData;
+  const { alias, docPath, repo, rawUrl, branch, slug } = docData;
 
   let docSourceUrl = `${rawUrl}/${branch}/${docPath}`;
 
@@ -105,6 +106,10 @@ function loadAndSaveDoc(docData) {
       // if TOC has different alias, we'll use that
       if (alias) {
         docSet.alias = alias;
+      }
+
+      if (slug) {
+        docSet.slug = slug;
       }
 
       // pre-process documentation
@@ -350,6 +355,10 @@ Meteor.methods({
             docSet.alias = tocItem.alias;
           }
 
+          if (tocItem.slug) {
+            docSet.slug = tocItem.slug;
+          }
+
            // if TOC has different label, we'll use that
           if (tocItem.label) {
             let label = tocItem.label;
@@ -475,6 +484,23 @@ Meteor.methods({
           if (tocItem.type === 'dir') {
             tocData.docPath += '/README.md';
           }
+
+          // check for parent doc for slug creation
+          let slug = '';
+          let slugParentDoc = {};
+          if (tocData.parentPath) {
+            slugParentDoc = ReDoc.Collections.TOC.findOne({ docPath: tocData.parentPath + '/README.md' });
+            if (slugParentDoc) {
+              slug = slugParentDoc.slug + '/' + s.slugify(tocData.label);
+            }
+          } else {
+            if (Meteor.settings.public.redoc.repoInLinks) {
+              slug = `${repo}/${branch}/${s.slugify(tocData.label)}`;
+            } else {
+              slug = `${branch}/${s.slugify(tocData.label)}`;
+            }
+          }
+          tocData.slug = slug;
           ReDoc.Collections.TOC.insert(tocData);
           if (tocItem.type === 'dir') {
             Meteor.call("redoc/getRepoTOC", repo, branch, tocItem.path, (level || 1) + 1);

--- a/packages/redoc-core/server/methods.js
+++ b/packages/redoc-core/server/methods.js
@@ -46,7 +46,7 @@ md = require("markdown-it")({
           docPath: link.substring(1)
         });
         if (tocItem) {
-          newLink = `${global.baseURL}/${item.slug}`;
+          newLink = `${global.baseURL}/${tocItem.slug}`;
         }
         break;
       default:


### PR DESCRIPTION
Added support for friendly URLs/permalinks:
![redoc-permalinks](https://cloud.githubusercontent.com/assets/190883/14587402/ba04400a-0488-11e6-9c6b-2bd3f7f3e6cb.gif)

This should not require any structure change on `Rocket.Chat.Docs`. However, it's worth mentioning that articles should link to another articles following GitHub's URLs. `RocketChat/redoc` is in charge of replacing valid GitHub URLs with its own friendly URLs in a way user can navigate through content accordingly.
