### PR TITLE
Fixing link replacement for relative paths

### DIFF
--- a/common/docs/toc.jsx
+++ b/common/docs/toc.jsx
@@ -67,7 +67,7 @@ export default DocView = React.createClass({
 
     for (let item of parentItems) {
       const branch = this.props.params.branch || Meteor.settings.public.redoc.branch || "master";
-      let url = `${global.baseURL}/${item.slug}`;
+      let url = `${global.baseURL}/${item.slug}/`;
 
       let subList;
 

--- a/packages/redoc-core/server/methods.js
+++ b/packages/redoc-core/server/methods.js
@@ -50,7 +50,12 @@ md = require("markdown-it")({
         }
         break;
       default:
-        newlink = link;
+        if (link.search(/\.([a-zA-Z0-9])+$/) !== -1) {
+          newLink = `${env.rawUrl}/${env.branch}/${env.docPath.replace('README.md', link)}`;
+        } else {
+          newLink = s.slugify(decodeURIComponent(link.replace(/^(\d+)[ \.]+/, '')));
+        }
+        break;
       }
     }
     return newLink;
@@ -120,6 +125,7 @@ function loadAndSaveDoc(docData) {
 
       docSet.docPageContent = result.content;
       docSet.docPageContentHTML = md.render(result.content, {
+        docPath,
         rawUrl: rawUrl,
         branch: branch,
         alias: docSet.alias,
@@ -379,6 +385,7 @@ Meteor.methods({
 
           docSet.docPageContent = result.content;
           docSet.docPageContentHTML = md.render(result.content, {
+            docPath: tocItem.docPath,
             rawUrl: docRepo.rawUrl,
             branch: branch,
             alias: tocItem.alias,


### PR DESCRIPTION
Works for both folders and files
![redoc-relative-url](https://cloud.githubusercontent.com/assets/190883/14903188/d847fc82-0d75-11e6-892d-6ec2e6185afd.gif)
